### PR TITLE
Update rabbitmq dotnet version

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,6 +21,9 @@ jobs:
         uses: actions/setup-dotnet@v3
         with:
           global-json-file: global.json
+          dotnet-version: |
+            9.0.x
+            8.0.x
 
       - name: Run build with warnings
         run: dotnet build /p:TreatWarningsAsErrors=true /consoleloggerparameters:NoSummary

--- a/KeyShot.Rebus.RabbitMq.Timeouts.Tests/KeyShot.Rebus.RabbitMq.Timeouts.Tests.csproj
+++ b/KeyShot.Rebus.RabbitMq.Timeouts.Tests/KeyShot.Rebus.RabbitMq.Timeouts.Tests.csproj
@@ -1,21 +1,25 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net8.0</TargetFramework>
+        <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
 
         <IsPackable>false</IsPackable>
         <IsTestProject>true</IsTestProject>
+        <TestTfmsInParallel>false</TestTfmsInParallel>
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="coverlet.collector" Version="6.0.0"/>
+        <PackageReference Include="coverlet.collector" Version="6.0.4">
+          <PrivateAssets>all</PrivateAssets>
+          <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+        </PackageReference>
         <PackageReference Include="GitHubActionsTestLogger" Version="2.4.1">
           <PrivateAssets>all</PrivateAssets>
           <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0"/>
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
         <PackageReference Include="NUnit" Version="3.14.0"/>
         <PackageReference Include="NUnit.Analyzers" Version="3.9.0"/>
         <PackageReference Include="NUnit3TestAdapter" Version="4.5.0"/>

--- a/KeyShot.Rebus.RabbitMq.Timeouts.Tests/TestHelper.cs
+++ b/KeyShot.Rebus.RabbitMq.Timeouts.Tests/TestHelper.cs
@@ -11,7 +11,7 @@ public static class TestHelper
     public const int Port = 5672;
     public const string HostName = "localhost";
     
-    public static void DeleteTestQueue()
+    public static async Task DeleteTestQueue()
     {
         
         var connectionFactory = new ConnectionFactory()
@@ -25,8 +25,8 @@ public static class TestHelper
             HostName = HostName,
         };
 
-        using var connection = connectionFactory.CreateConnection();
-        using var model = connection.CreateModel();
-        model.QueueDelete(TimeoutQueueName);
+        await using var connection = await connectionFactory.CreateConnectionAsync();
+        await using var model = await connection.CreateChannelAsync();
+        await model.QueueDeleteAsync(TimeoutQueueName);
     }
 }

--- a/KeyShot.Rebus.RabbitMq.Timeouts.Tests/Tests.cs
+++ b/KeyShot.Rebus.RabbitMq.Timeouts.Tests/Tests.cs
@@ -24,13 +24,13 @@ public class OtherTests : FixtureBase
 {
     protected override void SetUp()
     {
-        TestHelper.DeleteTestQueue();
+        TestHelper.DeleteTestQueue().GetAwaiter().GetResult();
         base.SetUp();
     }
 
     protected override void TearDown()
     {
-        TestHelper.DeleteTestQueue();
+        TestHelper.DeleteTestQueue().GetAwaiter().GetResult();
         base.TearDown();
     }
 
@@ -48,7 +48,7 @@ public class OtherTests : FixtureBase
             TimeoutQueueName = TestHelper.TimeoutQueueName,
         }, consoleLoggerFactory, new FakeRebusTime());
 
-        manager.Initialize();
+        await manager.InitializeAsync();
 
         await manager.Defer(DateTimeOffset.UnixEpoch, new Dictionary<string, string>(), [1]);
 

--- a/KeyShot.Rebus.RabbitMq.Timeouts.Tests/TimeoutFactory.cs
+++ b/KeyShot.Rebus.RabbitMq.Timeouts.Tests/TimeoutFactory.cs
@@ -28,7 +28,7 @@ public class TimeoutFactory : ITimeoutManagerFactory
 
     public void Cleanup()
     {
-        TestHelper.DeleteTestQueue();   
+        TestHelper.DeleteTestQueue().GetAwaiter().GetResult();   
     }
 
     public string GetDebugInfo()

--- a/KeyShot.Rebus.RabbitMq.Timeouts/KeyShot.Rebus.RabbitMq.Timeouts.csproj
+++ b/KeyShot.Rebus.RabbitMq.Timeouts/KeyShot.Rebus.RabbitMq.Timeouts.csproj
@@ -1,19 +1,19 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>netstandard2.0</TargetFramework>
+        <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <LangVersion>12</LangVersion>
     </PropertyGroup>
 
     <ItemGroup>
-      <PackageReference Include="PolySharp" Version="1.14.1">
+      <PackageReference Include="PolySharp" Version="1.15.0">
         <PrivateAssets>all</PrivateAssets>
         <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       </PackageReference>
-      <PackageReference Include="RabbitMQ.Client" Version="6.8.1" />
-      <PackageReference Include="Rebus" Version="8.6.0" />
+      <PackageReference Include="RabbitMQ.Client" Version="7.0.0" />
+      <PackageReference Include="Rebus" Version="8.7.1" />
     </ItemGroup>
 
 </Project>

--- a/KeyShot.Rebus.RabbitMq.Timeouts/QueuedMessage.cs
+++ b/KeyShot.Rebus.RabbitMq.Timeouts/QueuedMessage.cs
@@ -5,44 +5,48 @@ namespace KeyShot.Rebus.RabbitMq.Timeouts;
 sealed class QueuedMessage
 {
     public readonly ulong DeliveryTag;
-    public readonly Dictionary<string, string> Headers;
+    public readonly Dictionary<string, string?> Headers;
     public readonly byte[] Body;
     private readonly TimeoutConsumer _consumer;
     public readonly long DueTime;
 
-    public QueuedMessage(ulong deliveryTag, IDictionary<string, object> headers, ReadOnlyMemory<byte> body,
+    public QueuedMessage(ulong deliveryTag, IDictionary<string, object?>? headers, ReadOnlyMemory<byte> body,
         TimeoutConsumer consumer)
     {
         DeliveryTag = deliveryTag;
 
         Headers = new();
-        foreach (var pair in headers)
+        if (headers != null)
         {
-            if (pair.Key == RebusRabbitMqTimeoutHeaders.DueTime)
+            foreach (var pair in headers)
             {
-                continue;
+                if (pair.Key == RebusRabbitMqTimeoutHeaders.DueTime)
+                {
+                    continue;
+                }
+
+                if (pair.Value is byte[] bytes)
+                {
+                    Headers.Add(pair.Key, Encoding.UTF8.GetString(bytes));
+                    continue;
+                }
+
+                Headers.Add(pair.Key, pair.Value?.ToString()!);
             }
-            
-            if(pair.Value is byte[] bytes)
-            {
-                Headers.Add(pair.Key, Encoding.UTF8.GetString(bytes));
-                continue;
-            }
-            Headers.Add(pair.Key, pair.Value.ToString()!);
+
+
+            DueTime = (long)(headers[RebusRabbitMqTimeoutHeaders.DueTime] ?? 0);
         }
-        
-        
-        DueTime = (long)headers[RebusRabbitMqTimeoutHeaders.DueTime];
-        
-        
+
+
         _consumer = consumer;
         Body = body.ToArray();
     }
 
-    public void Ack()
+    public ValueTask Ack()
     {
         _consumer.RemoveFromQueue(DeliveryTag);
         
-        _consumer.Model.BasicAck(DeliveryTag, multiple: false);
+        return _consumer.Channel.BasicAckAsync(DeliveryTag, multiple: false);
     }
 }

--- a/KeyShot.Rebus.RabbitMq.Timeouts/QueuedMessage.cs
+++ b/KeyShot.Rebus.RabbitMq.Timeouts/QueuedMessage.cs
@@ -10,7 +10,7 @@ sealed class QueuedMessage
     private readonly TimeoutConsumer _consumer;
     public readonly long DueTime;
 
-    public QueuedMessage(ulong deliveryTag, IDictionary<string, object?>? headers, ReadOnlyMemory<byte> body,
+    public QueuedMessage(ulong deliveryTag, IDictionary<string, object?>? headers, byte[] body,
         TimeoutConsumer consumer)
     {
         DeliveryTag = deliveryTag;
@@ -40,7 +40,7 @@ sealed class QueuedMessage
 
 
         _consumer = consumer;
-        Body = body.ToArray();
+        Body = body;
     }
 
     public ValueTask Ack()

--- a/KeyShot.Rebus.RabbitMq.Timeouts/RabbitMqTimeoutManager.cs
+++ b/KeyShot.Rebus.RabbitMq.Timeouts/RabbitMqTimeoutManager.cs
@@ -59,15 +59,15 @@ public sealed class RabbitMqTimeoutManager : ITimeoutManager, IInitializable, ID
         _log.Debug("Message deferred until {dueTime}", approximateDueTime);
     }
 
-    public Task<DueMessagesResult> GetDueMessages()
+    public async Task<DueMessagesResult> GetDueMessages()
     {
         ForcedTestDelay();
         
         var consumer = RequireConsumer();
         if (!consumer.Channel.IsOpen)
         {
-            _log.Debug("Consumer model is closed, reinitializing");
-            Initialize();
+            _log.Debug("Consumer channel is closed, reinitializing");
+            await InitializeAsync();
             consumer = RequireConsumer();
             ForcedTestDelay();
         }
@@ -78,15 +78,14 @@ public sealed class RabbitMqTimeoutManager : ITimeoutManager, IInitializable, ID
             .Where(message => message.DueTime <= now)
             .Select(message =>
             {
-                return new DueMessage(message.Headers, message.Body.ToArray(), () =>
+                return new DueMessage(message.Headers, message.Body.ToArray(), async () =>
                 {
-                    message.Ack();
-                    return Task.CompletedTask;
+                    await message.Ack();
                 });
             })
             .ToList();
 
-        return Task.FromResult(new DueMessagesResult(messages));
+        return new DueMessagesResult(messages);
     }
 
     [Conditional("DEBUG")]

--- a/KeyShot.Rebus.RabbitMq.Timeouts/RabbitMqTimeoutManager.cs
+++ b/KeyShot.Rebus.RabbitMq.Timeouts/RabbitMqTimeoutManager.cs
@@ -1,5 +1,4 @@
 ﻿using System.Diagnostics;
-using System.Text;
 using RabbitMQ.Client;
 using RabbitMQ.Client.Exceptions;
 using Rebus.Bus;
@@ -9,13 +8,14 @@ using Rebus.Timeouts;
 
 namespace KeyShot.Rebus.RabbitMq.Timeouts;
 
-public sealed class RabbitMqTimeoutManager : ITimeoutManager, IInitializable, IDisposable
+public sealed class RabbitMqTimeoutManager : ITimeoutManager, IInitializable, IDisposable, IAsyncDisposable
 {
     private readonly ILog _log;
     private readonly ILog _timeoutConsumerLog;
     private TimeoutConsumer? _consumer;
     private readonly IRebusTime _rebusTime;
     private readonly RabbitMqTimeoutOptions _options;
+    private readonly SemaphoreSlim _initLock = new(1, 1);
 
     public RabbitMqTimeoutManager(RabbitMqTimeoutOptions options, IRebusLoggerFactory loggerFactory,
         IRebusTime rebusTime)
@@ -39,25 +39,24 @@ public sealed class RabbitMqTimeoutManager : ITimeoutManager, IInitializable, ID
         catch (RabbitMQClientException e)
         {
             _log.Warn(e, "RabbitMQ client exception encountered while attempting to defer message. Reinitializing client and trying again.");
-            Initialize();
+            await InitializeAsync();
 
             await DeferCore(approximateDueTime, headers, body);
         }
     }
 
-    private Task DeferCore(DateTimeOffset approximateDueTime, Dictionary<string, string> headers, byte[] body)
+    private async ValueTask DeferCore(DateTimeOffset approximateDueTime, Dictionary<string, string> headers, byte[] body)
     {
         var consumer = RequireConsumer();
             
-        var properties = consumer.Model.CreateBasicProperties();
-        properties.Headers = headers.ToDictionary(p => p.Key, p => (object)p.Value);
+        var properties = new BasicProperties();
+        properties.Headers = headers.ToDictionary(p => p.Key, object? (p) => p.Value);
         properties.Headers[RebusRabbitMqTimeoutHeaders.DueTime] = approximateDueTime.ToUnixTimeMilliseconds();
 
-        consumer.Model.BasicPublish(exchange: string.Empty, routingKey: _options.TimeoutQueueName, mandatory: true,
+        await consumer.Channel.BasicPublishAsync(exchange: string.Empty, routingKey: _options.TimeoutQueueName, mandatory: true,
             properties, body);
 
         _log.Debug("Message deferred until {dueTime}", approximateDueTime);
-        return Task.CompletedTask;
     }
 
     public Task<DueMessagesResult> GetDueMessages()
@@ -65,7 +64,7 @@ public sealed class RabbitMqTimeoutManager : ITimeoutManager, IInitializable, ID
         ForcedTestDelay();
         
         var consumer = RequireConsumer();
-        if (!consumer.Model.IsOpen)
+        if (!consumer.Channel.IsOpen)
         {
             _log.Debug("Consumer model is closed, reinitializing");
             Initialize();
@@ -110,10 +109,20 @@ public sealed class RabbitMqTimeoutManager : ITimeoutManager, IInitializable, ID
 
     public void Initialize()
     {
-        lock (this)
+        InitializeAsync().GetAwaiter().GetResult();
+    }
+
+    public async Task InitializeAsync()
+    {
+        await _initLock.WaitAsync();
+        try
         {
-            _consumer?.Dispose();
-            _consumer = null;
+            if (_consumer is { } c)
+            {
+                _consumer = null;
+                await c.DisposeAsync();
+            }
+
             var connectionFactory = new ConnectionFactory()
             {
                 AutomaticRecoveryEnabled = true,
@@ -125,24 +134,37 @@ public sealed class RabbitMqTimeoutManager : ITimeoutManager, IInitializable, ID
                 HostName = _options.HostName,
             };
 
-            var connection = connectionFactory.CreateConnection();
-            var channel = connection.CreateModel();
-            channel.BasicQos(prefetchCount: _options.PrefetchCount, prefetchSize: 0, global: false);
+            var connection = await connectionFactory.CreateConnectionAsync();
+            var channel = await connection.CreateChannelAsync();
+            await channel.BasicQosAsync(prefetchCount: _options.PrefetchCount, prefetchSize: 0, global: false);
 
-            channel.QueueDeclare(_options.TimeoutQueueName, durable: true, exclusive: false, autoDelete: false,
+            await channel.QueueDeclareAsync(_options.TimeoutQueueName, durable: true, exclusive: false,
+                autoDelete: false,
                 arguments: _options.QueueArguments);
 
 
             _consumer = new TimeoutConsumer(channel, connection, _timeoutConsumerLog);
 
-            channel.BasicConsume(_options.TimeoutQueueName, autoAck: false, _consumer);
+            await channel.BasicConsumeAsync(_options.TimeoutQueueName, autoAck: false, _consumer);
+        }
+        finally
+        {
+            _initLock.Release();
         }
     }
 
 
     public void Dispose()
     {
-        _consumer?.Dispose();
+        DisposeAsync().AsTask().GetAwaiter().GetResult();
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        if (_consumer is { } c)
+        {
+            await c.DisposeAsync();
+        }
     }
 }
 

--- a/KeyShot.Rebus.RabbitMq.Timeouts/RabbitMqTimeoutOptions.cs
+++ b/KeyShot.Rebus.RabbitMq.Timeouts/RabbitMqTimeoutOptions.cs
@@ -13,5 +13,5 @@ public sealed class RabbitMqTimeoutOptions
 
     public ushort PrefetchCount { get; set; } = 100;
 
-    public Dictionary<string, object> QueueArguments { get; set; } = new();
+    public Dictionary<string, object?> QueueArguments { get; set; } = new();
 }

--- a/KeyShot.Rebus.RabbitMq.Timeouts/TimeoutConsumer.cs
+++ b/KeyShot.Rebus.RabbitMq.Timeouts/TimeoutConsumer.cs
@@ -4,25 +4,27 @@ using Rebus.Logging;
 
 namespace KeyShot.Rebus.RabbitMq.Timeouts;
 
-sealed class TimeoutConsumer : DefaultBasicConsumer, IDisposable
+sealed class TimeoutConsumer : AsyncDefaultBasicConsumer, IDisposable, IAsyncDisposable
 {
     private readonly IConnection _connection;
     private readonly ConcurrentDictionary<ulong, QueuedMessage> _queuedMessages = new();
     private readonly ILog _log;
 
-    public TimeoutConsumer(IModel model, IConnection connection, ILog log) : base(model)
+    public TimeoutConsumer(IChannel model, IConnection connection, ILog log) : base(model)
     {
         _connection = connection;
         _log = log;
     }
 
-    public override void HandleBasicDeliver(string consumerTag, ulong deliveryTag, bool redelivered, string exchange,
-        string routingKey,
-        IBasicProperties properties, ReadOnlyMemory<byte> body)
+
+    public override Task HandleBasicDeliverAsync(string consumerTag, ulong deliveryTag, bool redelivered, string exchange,
+        string routingKey, IReadOnlyBasicProperties properties, ReadOnlyMemory<byte> body,
+        CancellationToken cancellationToken = default)
     {
         _log.Debug("Received message with delivery tag {deliveryTag}", deliveryTag);
-        var message = new QueuedMessage(deliveryTag, properties.Headers, body, this);
+        var message = new QueuedMessage(deliveryTag, properties.Headers, body.ToArray(), this);
         _queuedMessages.TryAdd(deliveryTag, message);
+        return Task.CompletedTask;
     }
 
     public IEnumerable<QueuedMessage> GetMessages()
@@ -37,6 +39,11 @@ sealed class TimeoutConsumer : DefaultBasicConsumer, IDisposable
 
     public void Dispose()
     {
-        _connection.Abort();
+        DisposeAsync().AsTask().GetAwaiter().GetResult();
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        await _connection.AbortAsync();
     }
 }

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "8.0.300",
+    "version": "9.0.102",
     "rollForward": "latestFeature",
     "allowPrerelease": false
   }


### PR DESCRIPTION
V7 has full support for async-await (FINALLY). Rebus has released a version of Rebus.rabbitmq that supports this version, however before we can test it probably this also need to be updated.

Before you ask: No, we should not merge any of this into 6.2 at this point. I just want to ready so i can do it early in 6.3 once we branch. 